### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/TVout/keywords.txt
+++ b/TVout/keywords.txt
@@ -17,7 +17,7 @@ invert	KEYWORD2
 
 begin	KEYWORD2
 end	KEYWORD2
-force_vscale KEYWORD2
+force_vscale	KEYWORD2
 force_outstart	KEYWORD2
 force_linestart	KEYWORD2
 hres	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords